### PR TITLE
[CHANGE]: Desabilitar botão do wpp se não tiver serviço selecionado

### DIFF
--- a/src/app/(aplication)/page.module.css
+++ b/src/app/(aplication)/page.module.css
@@ -232,7 +232,6 @@
 .serviceDescription {
   font-size: 12px;
   color: rgb(34, 33, 33);
-  height: 20px;
 }
 
 .serviceContent {
@@ -287,6 +286,10 @@
   align-items: center;
   gap: 10px;
 
+}
+
+.buttonDisabled {
+  background-color: var(--secondary) !important;
 }
 
 /* ---------- responsive */

--- a/src/app/(aplication)/service/page.tsx
+++ b/src/app/(aplication)/service/page.tsx
@@ -22,6 +22,10 @@ export default function page() {
     }
   }
 
+  function buttonDisabled() {
+    return !!selectedService.length
+  }
+
   function sendMessage() {
     window.open(`https://whatsa.me/5585998473291/?t=${message}`)
   }
@@ -67,15 +71,16 @@ export default function page() {
       </div>
 
       {ctx.selectedProfessional &&
-        <div className={style.buttonWhatsappDiv}>
-          <ConfirmButton action={sendMessage} title='Confirmar' icon='fa-brands fa-whatsapp' />
+        <div className={`${style.buttonWhatsappDiv}`}>
+          <ConfirmButton disabled={!buttonDisabled()} action={sendMessage} title='Confirmar' icon='fa-brands fa-whatsapp' />
         </div>
       }
       {!ctx.selectedProfessional &&
-        <div className={style.buttonWhatsappDiv}>
-          <ConfirmButton action={redirectRoute} title='Profissionais' icon='' />
+        <div
+          className={style.buttonWhatsappDiv}>
+          <ConfirmButton disabled={false} action={redirectRoute} title='Profissionais' icon='' />
         </div>
       }
-    </div>
+    </div >
   )
-}
+} 

--- a/src/app/components/CardService.tsx
+++ b/src/app/components/CardService.tsx
@@ -35,10 +35,6 @@ export default function CardService({ service, selected }: Props) {
         return '';
     }
 
-    console.log(searchProfessional(service))
-
-    console.log(searchProfessional(service))
-
     return (
         <div className={style.serviceItem} onClick={handleServiceItemClick}>
             <div className={style.serviceTitle}>

--- a/src/app/components/ConfirmButton.tsx
+++ b/src/app/components/ConfirmButton.tsx
@@ -6,11 +6,16 @@ type Props = {
     action: () => void,
     title: string,
     icon: string
+    disabled: boolean
 }
 
-export default function ConfirmButton({ action, title, icon}: Props) {
+function styleDisabledButton(disabled: boolean) {
+    return disabled ? style.buttonDisabled : ''
+  }
+
+export default function ConfirmButton({ action, title, icon, disabled, }: Props) {
     return (
-        <button onClick={action}>
+        <button disabled={disabled} onClick={action} className={styleDisabledButton(disabled)}>
             {title} <i className={icon}></i>
         </button>
     )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 
 :root {
   --primary: #BC85FC;
+  --secondary: rgb(170, 170, 170);
   --light: #ffff;
   --progress: #F87C09;
   --bg-footer: #D9D9D9;


### PR DESCRIPTION
1. Foi ajustado o layout do card de de serviços
2. foi adicionado o disabled do botão de encaminhar para whatsapp quando não tem serviço selecionado